### PR TITLE
Force symfony/console below <2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "pimcore/installer-plugin": ">=1",
         "composer/composer": "1.0.*@dev",
+        "symfony/console": "~2.6.0",
         "knplabs/packagist-api": "1.*@dev"
     }
 }


### PR DESCRIPTION
See: https://github.com/composer/composer/pull/3759

[Verification]
$ composer.phar create-project pimcore/pimcore
// add `"minimum-stability": "dev"` to project's composer.json
$ composer.phar require pimcore-extensions/manager:dev-composer-test

symfony/console 2.6.x-dev should be installed
